### PR TITLE
Problems with participant stage

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 general:
   artifacts:
-    - "~/result"
+    - "~/outputs"
 machine:
   services:
     - docker #don't use 1.10 - caching is broken
@@ -20,8 +20,13 @@ dependencies:
 
 test:
   override:
-    - case $CIRCLE_NODE_INDEX in 0) docker run -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} group /bids_dataset /outputs ;; 1) docker run -it --read-only -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} participant /bids_dataset /outputs --participant_label "2" ;; 2) docker run -it --read-only -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} participant /bids_dataset /outputs --participant_label "3"  ;; 3) docker run -it --read-only -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} participant /bids_dataset /outputs --participant_label "4"  ;; esac:
-        parallel: true
+    - docker run --read-only -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} participant /bids_dataset /outputs --participant_label 2 :
+        timeout: 21600
+    - docker run --read-only -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} participant /bids_dataset /outputs --participant_label 3 :
+        timeout: 21600
+    - docker run --read-only -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} participant /bids_dataset /outputs --participant_label 4 :
+        timeout: 21600
+    - docker run --read-only -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} group /bids_dataset /outputs --participant_label 2 3 4 :
         timeout: 21600
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -20,13 +20,11 @@ dependencies:
 
 test:
   override:
-    - docker run --read-only -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} participant /bids_dataset /outputs --participant_label 2 :
+    - docker run --read-only -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} participant /bids_dataset /outputs --participant_label 0274 :
         timeout: 21600
-    - docker run --read-only -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} participant /bids_dataset /outputs --participant_label 3 :
+    - docker run --read-only -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} participant /bids_dataset /outputs --participant_label 0275 :
         timeout: 21600
-    - docker run --read-only -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} participant /bids_dataset /outputs --participant_label 4 :
-        timeout: 21600
-    - docker run --read-only -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} group /bids_dataset /outputs --participant_label 2 3 4 :
+    - docker run --read-only -it -v ${HOME}/outputs:/outputs -v ${HOME}/data/sample_test:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} group /bids_dataset /outputs --participant_label 0274 0275 :
         timeout: 21600
 
 deployment:


### PR DESCRIPTION
This PR is an attempt to clean up the circle.yml file by:
- saving outputs as artifacts
- removing parallelization of tests (it does not work on our plan
- running participant stages before group stage

However it exemplifies a problem with the niak app. Independently of what --_participant_label value is set in the "participant" stage the app runs for over 2h without producing any output. However the group level is running and performing the participant (slice time correction coregistration etc) and group level analysis! Those two stages need to be split.
